### PR TITLE
Display member name in AtMessageShown

### DIFF
--- a/src/components/MessageShown/TextMessageShown.tsx
+++ b/src/components/MessageShown/TextMessageShown.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import type { Component } from 'solid-js'
 import { Show } from 'solid-js'
 import { transformLink } from '~/utils/hook/transformLink'
+import { Conversation, curConv, groupMemberCard } from '~/utils/stores/lists'
 
 const TextMessageShown: Component<{
   text: string
@@ -12,7 +13,8 @@ const TextMessageShown: Component<{
 const AtMessageShown: Component<{
   qq: number
 }> = (props) => {
-  return <>@{props.qq}</>
+  const groupId = curConv()?.id
+  return <>@{(groupId && groupMemberCard[groupId]?.[props.qq]) || props.qq}</>
 }
 
 const ReplyMessageShown: Component<{

--- a/src/utils/stores/lists.ts
+++ b/src/utils/stores/lists.ts
@@ -50,6 +50,7 @@ const [warnings, setWarnings] = createSignal<WarningMessage[]>([])
 const [forwardMap, setForwardMap] = createStore<Record<string, ReceivedForwardedMessage>>({})
 const [lastForwardId, setLastforwardId] = createSignal('')
 const [groupFsStore, setGroupFsStore] = createStore<Record<string, GroupFsList>>({})
+const [groupMemberCard, setGroupMemberCard] = createStore<Record<string, Record<string, string>>>({}) // { group_id: { user_id: card | nickname } }
 
 function pushRightBottomMessage(config: Omit<WarningMessage, 'id'>) {
   const { ttl } = config
@@ -74,6 +75,7 @@ export {
   groupFsStore, setGroupFsStore,
   WarningType,
   pushRightBottomMessage,
+  groupMemberCard, setGroupMemberCard,
 }
 
 export type {

--- a/src/utils/stores/store.ts
+++ b/src/utils/stores/store.ts
@@ -1,6 +1,6 @@
 import type { ReceivedFriendRecall, ReceivedGroupMessage, ReceivedGroupRecall, ReceivedPrivateMessage } from '../api/received-msg-types'
 import { MessageTarget } from '../ws/ws'
-import { friendConvStore, groupConvStore, groupList, setFriendConvStore, setGroupConvStore } from './lists'
+import { friendConvStore, groupConvStore, groupList, groupMemberCard, setFriendConvStore, setGroupConvStore, setGroupMemberCard } from './lists'
 
 /**
  * Store the message with this group in a global storage (not permanently).
@@ -137,10 +137,16 @@ function recallGroupStore(data: ReceivedGroupMessage | ReceivedGroupRecall) {
   setGroupConvStore(idx1, 'list', idx2, 'deleted', true)
 }
 
+function addGroupMemberCard(data: ReceivedGroupMessage) {
+  setGroupMemberCard(String(data.group_id), groupMemberCard[data.group_id] || {})
+  setGroupMemberCard(String(data.group_id), String(data.user_id), data.sender.card || data.sender.nickname)
+}
+
 export {
   addFriendStore,
   addGroupStore,
   recallFriendStore,
   recallGroupStore,
   addGroupMessages,
+  addGroupMemberCard,
 }

--- a/src/utils/ws/instance.ts
+++ b/src/utils/ws/instance.ts
@@ -3,7 +3,7 @@ import type { ReceivedGroupMessage } from '../api/received-msg-types'
 import { isGroup, isPrivate } from '../api/received-msg-types'
 import { pushGroupConversation, pushPrivateConversation } from '../stores/conv'
 import { WarningType, lastForwardId, pushRightBottomMessage, sendEl, setForwardMap, setFriendList, setGroupFsStore, setGroupList, setLastforwardId } from '../stores/lists'
-import { addFriendStore, addGroupMessages, addGroupStore, recallFriendStore, recallGroupStore } from '../stores/store'
+import { addFriendStore, addGroupMemberCard, addGroupMessages, addGroupStore, recallFriendStore, recallGroupStore } from '../stores/store'
 import { isGroupUploadFile, isOfflineFile, receivedGroupUploadHandler, receivedOfflineFileHandler } from '../api/notice'
 import { _createFileMessage } from '../api/sent-message-type'
 import type { GroupFsList } from '../api/group-fs'
@@ -120,6 +120,7 @@ function initWs(url: string) {
     if (isGroup(data)) {
       pushGroupConversation(data)
       addGroupStore(data)
+      addGroupMemberCard(data)
       return
     }
 


### PR DESCRIPTION
The member name is taken from recent messages, not from full group member list. So we cannot get the member name if one has not say anything in the group.